### PR TITLE
fix md5 comm

### DIFF
--- a/md5.module.nf
+++ b/md5.module.nf
@@ -12,9 +12,11 @@ process md5sum {
     """
     # Allow this command to work on unix/macos
     if command -v md5sum; then
-      alias md5=md5sum
+      md5_comm=md5sum
+    else
+      md5_comm=md5
     fi;
-    md5 ${fq1} > md5.txt
-    md5 ${fq2} >> md5.txt
+    \${md5_comm} ${fq1} > md5.txt
+    \${md5_comm} ${fq2} >> md5.txt
     """
 }


### PR DESCRIPTION
@danrlu I noticed you reverted some changes. I'll leave it upto you whether you want to fold these in, but I want to point out a few details regarding those changes:

* The pipeline implements a post-md5 hash. You have removed this step.
* You must set an environmental variable when running and to work. That is why the pipeline asserts that the version must be == `20.01.0`; because this version is required for the updated syntax.

e.g. 
```bash
NXF_VER=20.01.0 nextflow 
```

* I had not tested this on quest, but have fixed the md5hash module.